### PR TITLE
sql: support Comment on constraint

### DIFF
--- a/docs/generated/sql/bnf/comment.bnf
+++ b/docs/generated/sql/bnf/comment.bnf
@@ -1,6 +1,7 @@
 comment_stmt ::=
 	'COMMENT' 'ON' 'DATABASE' database_name 'IS' comment_text
 	| 'COMMENT' 'ON' 'SCHEMA' schema_name 'IS' comment_text
+	| 'COMMENT' 'ON' 'CONSTRAINT' constraint_name 'IS' comment_text
 	| 'COMMENT' 'ON' 'TABLE' table_name 'IS' comment_text
 	| 'COMMENT' 'ON' 'COLUMN' column_name 'IS' comment_text
 	| 'COMMENT' 'ON' 'INDEX' table_index_name 'IS' comment_text

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -56,6 +56,7 @@ copy_from_stmt ::=
 comment_stmt ::=
 	'COMMENT' 'ON' 'DATABASE' database_name 'IS' comment_text
 	| 'COMMENT' 'ON' 'SCHEMA' schema_name 'IS' comment_text
+	| 'COMMENT' 'ON' 'CONSTRAINT' constraint_name 'IS' comment_text
 	| 'COMMENT' 'ON' 'TABLE' table_name 'IS' comment_text
 	| 'COMMENT' 'ON' 'COLUMN' column_path 'IS' comment_text
 	| 'COMMENT' 'ON' 'INDEX' table_index_name 'IS' comment_text
@@ -274,6 +275,9 @@ comment_text ::=
 	| 'NULL'
 
 schema_name ::=
+	name
+
+constraint_name ::=
 	name
 
 column_path ::=
@@ -2483,9 +2487,6 @@ col_qual_list ::=
 
 opt_family_name ::=
 	opt_name
-
-constraint_name ::=
-	name
 
 constraint_elem ::=
 	'CHECK' '(' a_expr ')'

--- a/pkg/ccl/importccl/read_import_pgdump.go
+++ b/pkg/ccl/importccl/read_import_pgdump.go
@@ -863,7 +863,7 @@ func readPostgresStmt(
 		// handled during the data ingestion pass.
 	case *tree.CreateExtension, *tree.CommentOnDatabase, *tree.CommentOnTable,
 		*tree.CommentOnIndex, *tree.CommentOnColumn, *tree.SetVar, *tree.Analyze,
-		*tree.CommentOnSchema:
+		*tree.CommentOnSchema,*tree.CommentOnConstraint:
 		// These are the statements that can be parsed by CRDB but are not
 		// supported, or are not required to be processed, during an IMPORT.
 		// - ignore txns.
@@ -1358,7 +1358,7 @@ func (m *pgDumpReader) readFile(
 			}
 		case *tree.CreateExtension, *tree.CommentOnDatabase, *tree.CommentOnTable,
 			*tree.CommentOnIndex, *tree.CommentOnColumn, *tree.AlterSequence,
-			*tree.CommentOnSchema:
+			*tree.CommentOnSchema,*tree.CommentOnConstraint:
 			// handled during schema extraction.
 		case *tree.SetVar, *tree.BeginTransaction, *tree.CommitTransaction, *tree.Analyze:
 			// handled during schema extraction.

--- a/pkg/keys/constants.go
+++ b/pkg/keys/constants.go
@@ -419,6 +419,7 @@ const (
 	ColumnCommentType   = 2
 	IndexCommentType    = 3
 	SchemaCommentType   = 4
+	ConstraintCommentType = 5
 )
 
 const (

--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -30,6 +30,7 @@ go_library(
         "check.go",
         "cluster_wide_id.go",
         "comment_on_column.go",
+        "comment_on_constraint.go",
         "comment_on_database.go",
         "comment_on_index.go",
         "comment_on_schema.go",

--- a/pkg/sql/comment_on_constraint.go
+++ b/pkg/sql/comment_on_constraint.go
@@ -79,7 +79,7 @@ func (n *commentOnConstraintNode) startExec(params runParams) error {
 			return err
 		}
 	} else {
-		err := params.p.removeConstraintComment(params.ctx, n.constraintInfo.tableDesc.GetID())
+		err := params.p.removeConstraintComment(params.ctx, n.constraintInfo.tableDesc.ID)
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/comment_on_constraint.go
+++ b/pkg/sql/comment_on_constraint.go
@@ -1,0 +1,108 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sql
+
+import (
+	"context"
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
+)
+
+type commentOnConstraintNode struct {
+	n         *tree.CommentOnConstraint
+	constraintInfo *ConstraintAndTable
+}
+
+// CommentOnConstraint add comment on a constraint.
+func (p *planner) CommentOnConstraint(ctx context.Context, n *tree.CommentOnConstraint) (planNode, error) {
+	if err := checkSchemaChangeEnabled(
+		ctx,
+		p.ExecCfg(),
+		"COMMENT ON CONSTRAINT",
+	); err != nil {
+		return nil, err
+	}
+
+	dbName := p.CurrentDatabase()
+	if dbName == "" {
+		return nil, pgerror.New(pgcode.UndefinedDatabase,
+			"cannot comment schema without being connected to a database")
+	}
+
+	desc, err := p.Descriptors().GetImmutableDatabaseByName(ctx, p.txn,
+		dbName, tree.DatabaseLookupFlags{Required: true})
+	if err != nil {
+		return nil, err
+	}
+
+
+	constraint,err := p.searchConstraintFromAllMutableTables(ctx,desc,n.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := p.CheckPrivilege(ctx, desc, privilege.CREATE); err != nil {
+		return nil, err
+	}
+
+	return &commentOnConstraintNode{n: n, constraintInfo: constraint}, nil
+
+}
+
+func (n *commentOnConstraintNode) startExec(params runParams) error {
+
+	if n.n.Comment != nil {
+		_, err := params.p.extendedEvalCtx.ExecCfg.InternalExecutor.ExecEx(
+			params.ctx,
+			"set-constraint-comment",
+			params.p.Txn(),
+			sessiondata.InternalExecutorOverride{User: security.RootUserName()},
+			"UPSERT INTO system.comments VALUES ($1, $2, 0, $3)",
+			keys.ConstraintCommentType,
+			n.constraintInfo.tableDesc.GetID(),
+			*n.n.Comment)
+		if err != nil {
+			return err
+		}
+	} else {
+		err := params.p.removeConstraintComment(params.ctx, n.constraintInfo.tableDesc.GetID())
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (p *planner) removeConstraintComment(
+	ctx context.Context, tableID descpb.ID,
+) error {
+	_, err := p.ExtendedEvalContext().ExecCfg.InternalExecutor.ExecEx(
+		ctx,
+		"delete-constraint-comment",
+		p.txn,
+		sessiondata.InternalExecutorOverride{User: security.RootUserName()},
+		"DELETE FROM system.comments WHERE type=$1 AND object_id=$2 AND sub_id=0",
+		keys.ConstraintCommentType,
+		tableID)
+
+	return err
+}
+
+func (n *commentOnConstraintNode) Next(runParams) (bool, error) { return false, nil }
+func (n *commentOnConstraintNode) Values() tree.Datums          { return tree.Datums{} }
+func (n *commentOnConstraintNode) Close(context.Context)        {}

--- a/pkg/sql/comment_on_constraint_test.go
+++ b/pkg/sql/comment_on_constraint_test.go
@@ -43,30 +43,10 @@ func TestCommentOnConstraint(t *testing.T) {
 		expect gosql.NullString
 	}{
 		{
-			`COMMENT ON CONSTRAINT test_constraint1 IS 'test_comment1';'`,
+			`COMMENT ON CONSTRAINT test_constraint1 IS 'test_comment1';`,
 			`SELECT conname FROM pg_constraint WHERE conname='test_constraint1';`,
 			gosql.NullString{String: `test_constraint1`, Valid: true},
 		},
-		{
-			`TRUNCATE test_table1;`,
-			`SELECT conname FROM pg_constraint WHERE conname='test_constraint1';`,
-			gosql.NullString{String: `test_constraint1`, Valid: true},
-		},
-		/*{
-			`COMMENT ON CONSTRAINT test_constraint1 IS NULL;`,
-			`SELECT conname FROM pg_constraint WHERE conname='test_constraint1';`,
-			gosql.NullString{Valid: false},
-		},
-		{
-			`COMMENT ON CONSTRAINT test_constraint1 IS 'test_comment2';`,
-			`SELECT conname FROM pg_constraint WHERE conname='test_constraint2';`,
-			gosql.NullString{String: `test_constraint1`, Valid: true},
-		},
-		{
-			`DROP TABLE test_table1;`,
-			`SELECT conname FROM pg_constraint WHERE conname='test_constraint1';`,
-			gosql.NullString{Valid: false},
-		},*/
 	}
 
 	for _, tc := range testCases {

--- a/pkg/sql/comment_on_constraint_test.go
+++ b/pkg/sql/comment_on_constraint_test.go
@@ -1,0 +1,86 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sql_test
+
+import (
+	"context"
+	gosql "database/sql"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/tests"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+)
+
+func TestCommentOnConstraint(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	params, _ := tests.CreateTestServerParams()
+	s, db, _ := serverutils.StartServer(t, params)
+	defer s.Stopper().Stop(context.Background())
+
+	if _, err := db.Exec(`
+		CREATE DATABASE dbase;
+		SET DATABASE = dbase;
+		CREATE TABLE test_table1 (val INT, CONSTRAINT test_constraint1 CHECK (val > 0));
+	`); err != nil {
+		t.Fatal(err)
+	}
+
+	testCases := []struct {
+		exec   string
+		query  string
+		expect gosql.NullString
+	}{
+		{
+			`COMMENT ON CONSTRAINT test_constraint1 IS 'test_comment1';'`,
+			`SELECT conname FROM pg_constraint WHERE conname='test_constraint1';`,
+			gosql.NullString{String: `test_constraint1`, Valid: true},
+		},
+		{
+			`TRUNCATE test_table1;`,
+			`SELECT conname FROM pg_constraint WHERE conname='test_constraint1';`,
+			gosql.NullString{String: `test_constraint1`, Valid: true},
+		},
+		/*{
+			`COMMENT ON CONSTRAINT test_constraint1 IS NULL;`,
+			`SELECT conname FROM pg_constraint WHERE conname='test_constraint1';`,
+			gosql.NullString{Valid: false},
+		},
+		{
+			`COMMENT ON CONSTRAINT test_constraint1 IS 'test_comment2';`,
+			`SELECT conname FROM pg_constraint WHERE conname='test_constraint2';`,
+			gosql.NullString{String: `test_constraint1`, Valid: true},
+		},
+		{
+			`DROP TABLE test_table1;`,
+			`SELECT conname FROM pg_constraint WHERE conname='test_constraint1';`,
+			gosql.NullString{Valid: false},
+		},*/
+	}
+
+	for _, tc := range testCases {
+		if _, err := db.Exec(tc.exec); err != nil {
+			t.Fatal(err)
+		}
+
+		row := db.QueryRow(tc.query)
+		var comment gosql.NullString
+		if err := row.Scan(&comment); err != nil {
+			t.Fatal(err)
+		}
+		if tc.expect != comment {
+			t.Fatalf("expected comment %v, got %v", tc.expect, comment)
+		}
+	}
+}

--- a/pkg/sql/opaque.go
+++ b/pkg/sql/opaque.go
@@ -120,6 +120,8 @@ func planOpaque(ctx context.Context, p *planner, stmt tree.Statement) (planNode,
 		return p.CommentOnIndex(ctx, n)
 	case *tree.CommentOnTable:
 		return p.CommentOnTable(ctx, n)
+	case *tree.CommentOnConstraint:
+		return p.CommentOnConstraint(ctx,n)
 	case *tree.CreateDatabase:
 		return p.CreateDatabase(ctx, n)
 	case *tree.CreateIndex:
@@ -242,6 +244,7 @@ func init() {
 		&tree.AlterRole{},
 		&tree.AlterRoleSet{},
 		&tree.CommentOnColumn{},
+		&tree.CommentOnConstraint{},
 		&tree.CommentOnDatabase{},
 		&tree.CommentOnSchema{},
 		&tree.CommentOnIndex{},

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -3369,6 +3369,10 @@ comment_stmt:
   {
     $$.val = &tree.CommentOnSchema{Name: tree.Name($4), Comment: $6.strPtr()}
   }
+| COMMENT ON CONSTRAINT constraint_name IS comment_text
+	{
+		$$.val = &tree.CommentOnConstraint{Name: tree.Name($4), Comment: $6.strPtr()}
+	}
 | COMMENT ON TABLE table_name IS comment_text
   {
     $$.val = &tree.CommentOnTable{Table: $4.unresolvedObjectName(), Comment: $6.strPtr()}

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -1428,6 +1428,9 @@ https://www.postgresql.org/docs/9.5/catalog-pg-description.html`,
 					descpb.IndexID(tree.MustBeDInt(objSubID)))
 				objSubID = tree.DZero
 				classOid = tree.NewDOid(catconstants.PgCatalogClassTableID)
+			case keys.ConstraintCommentType:
+				objID = tree.NewDOid(tree.MustBeDInt(objID))
+				classOid = tree.NewDOid(catconstants.PgCatalogConstraintTableID)
 			}
 			if err := addRow(
 				objID,

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -1430,6 +1430,7 @@ https://www.postgresql.org/docs/9.5/catalog-pg-description.html`,
 				classOid = tree.NewDOid(catconstants.PgCatalogClassTableID)
 			case keys.ConstraintCommentType:
 				objID = tree.NewDOid(tree.MustBeDInt(objID))
+				objSubID = tree.DZero
 				classOid = tree.NewDOid(catconstants.PgCatalogConstraintTableID)
 			}
 			if err := addRow(

--- a/pkg/sql/plan_opt.go
+++ b/pkg/sql/plan_opt.go
@@ -56,6 +56,7 @@ func (p *planner) prepareUsingOptimizer(ctx context.Context) (planFlags, error) 
 		*tree.Analyze,
 		*tree.BeginTransaction,
 		*tree.CommentOnColumn, *tree.CommentOnDatabase, *tree.CommentOnIndex, *tree.CommentOnTable, *tree.CommentOnSchema,
+		*tree.CommentOnConstraint,
 		*tree.CommitTransaction,
 		*tree.CopyFrom, *tree.CreateDatabase, *tree.CreateIndex, *tree.CreateView,
 		*tree.CreateSequence,

--- a/pkg/sql/sem/tree/BUILD.bazel
+++ b/pkg/sql/sem/tree/BUILD.bazel
@@ -29,6 +29,7 @@ go_library(
         "collatedstring.go",
         "comment_on_column.go",
         "comment_on_database.go",
+        "comment_on_constraint.go",
         "comment_on_index.go",
         "comment_on_schema.go",
         "comment_on_table.go",

--- a/pkg/sql/sem/tree/comment_on_constraint.go
+++ b/pkg/sql/sem/tree/comment_on_constraint.go
@@ -1,0 +1,43 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package tree
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/lexbase"
+)
+
+// CommentOnConstraint represents an COMMENT ON CONSTRAINT statement.
+type CommentOnConstraint struct {
+	Name Name
+	//Constraint constraint.Constraint
+	//*ColumnItem
+	Comment *string
+}
+
+// Format implements the NodeFormatter interface.
+func (n *CommentOnConstraint) Format(ctx *FmtCtx) {
+	ctx.WriteString("COMMENT ON CONSTRAINT ")
+	ctx.FormatNode(&n.Name)
+	ctx.WriteString(" IS ")
+	if n.Comment != nil {
+		// TODO(knz): Replace all this with ctx.FormatNode
+		// when COMMENT supports expressions.
+		if ctx.flags.HasFlags(FmtHideConstants) {
+			ctx.WriteString("'_'")
+		} else {
+			lexbase.EncodeSQLStringWithFlags(&ctx.Buffer, *n.Comment, ctx.flags.EncodeFlags())
+		}
+	} else {
+		ctx.WriteString("NULL")
+	}
+}
+
+

--- a/pkg/sql/sem/tree/stmt.go
+++ b/pkg/sql/sem/tree/stmt.go
@@ -471,6 +471,15 @@ func (*CommentOnColumn) StatementType() StatementType { return TypeDDL }
 func (*CommentOnColumn) StatementTag() string { return "COMMENT ON COLUMN" }
 
 // StatementReturnType implements the Statement interface.
+func (*CommentOnConstraint) StatementReturnType() StatementReturnType { return DDL }
+
+// StatementType implements the Statement interface.
+func (*CommentOnConstraint) StatementType() StatementType { return TypeDDL }
+
+// StatementTag returns a short string identifying the type of statement.
+func (*CommentOnConstraint) StatementTag() string { return "COMMENT ON CONSTRAINT" }
+
+// StatementReturnType implements the Statement interface.
 func (*CommentOnDatabase) StatementReturnType() StatementReturnType { return DDL }
 
 // StatementType implements the Statement interface.
@@ -1635,6 +1644,7 @@ func (n *CancelQueries) String() string                  { return AsString(n) }
 func (n *CancelSessions) String() string                 { return AsString(n) }
 func (n *CannedOptPlan) String() string                  { return AsString(n) }
 func (n *CommentOnColumn) String() string                { return AsString(n) }
+func (n *CommentOnConstraint) String() string            { return AsString(n) }
 func (n *CommentOnDatabase) String() string              { return AsString(n) }
 func (n *CommentOnSchema) String() string                { return AsString(n) }
 func (n *CommentOnIndex) String() string                 { return AsString(n) }

--- a/pkg/sql/walk.go
+++ b/pkg/sql/walk.go
@@ -356,6 +356,7 @@ var planNodeNames = map[reflect.Type]string{
 	reflect.TypeOf(&cancelSessionsNode{}):             "cancel sessions",
 	reflect.TypeOf(&changePrivilegesNode{}):           "change privileges",
 	reflect.TypeOf(&commentOnColumnNode{}):            "comment on column",
+	reflect.TypeOf(&commentOnConstraintNode{}):        "comment on constraint",
 	reflect.TypeOf(&commentOnDatabaseNode{}):          "comment on database",
 	reflect.TypeOf(&commentOnIndexNode{}):             "comment on index",
 	reflect.TypeOf(&commentOnTableNode{}):             "comment on table",


### PR DESCRIPTION
This change adds associating comment to the constraint by using this syntax COMMENT ON CONSTRAINT <constraint_name> IS <comment>;